### PR TITLE
Fix for UK locale of 'Virtualisation' rather than 'Virtualization' in lscpu output

### DIFF
--- a/scripts/install-prerequisites.sh
+++ b/scripts/install-prerequisites.sh
@@ -52,7 +52,7 @@ function check_virtualization() {
     return
   fi
 
-  lscpu | grep Virtualization
+  lscpu | grep "Virtuali[s|z]ation"
   lsmod | grep kvm
 }
 


### PR DESCRIPTION
Hi All,

Great project, am thoroughly enjoying using it.  A minor one, my Ubuntu host 20.04.2 is configured with a UK locale.  This results in it changing z's to s's in the likes of lscpu, for example - 

```
root@kubefire:~# lscpu
Architecture:                    x86_64
CPU op-mode(s):                  32-bit, 64-bit
Byte Order:                      Little Endian
Address sizes:                   45 bits physical, 48 bits virtual
CPU(s):                          6
On-line CPU(s) list:             0-5
Thread(s) per core:              1
Core(s) per socket:              3
Socket(s):                       2
NUMA node(s):                    1
Vendor ID:                       GenuineIntel
CPU family:                      6
Model:                           79
Model name:                      Intel(R) Xeon(R) CPU E5-2620 v4 @ 2.10GHz
Stepping:                        1
CPU MHz:                         2099.998
BogoMIPS:                        4199.99
Virtualisation:                  VT-x
Hypervisor vendor:               VMware
Virtualisation type:             full
L1d cache:                       192 KiB
L1i cache:                       192 KiB
L2 cache:                        1.5 MiB
L3 cache:                        40 MiB
NUMA node0 CPU(s):               0-5
Vulnerability Itlb multihit:     KVM: Mitigation: Split huge pages
Vulnerability L1tf:              Mitigation; PTE Inversion; VMX flush not necessary, SMT disabled
Vulnerability Mds:               Mitigation; Clear CPU buffers; SMT Host state unknown
Vulnerability Meltdown:          Mitigation; PTI
Vulnerability Spec store bypass: Mitigation; Speculative Store Bypass disabled via prctl and seccomp
Vulnerability Spectre v1:        Mitigation; usercopy/swapgs barriers and __user pointer sanitization
Vulnerability Spectre v2:        Mitigation; Full generic retpoline, IBPB conditional, IBRS_FW, STIBP disabled, RSB filling
Vulnerability Srbds:             Not affected
Vulnerability Tsx async abort:   Not affected
Flags:                           fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ss ht syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon nopl xtopology tsc_reliable nonstop_tsc cpuid pni pclmulqdq vmx ssse3 fma cx16 p
                                 cid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand hypervisor lahf_lm abm 3dnowprefetch cpuid_fault invpcid_single pti ssbd ibrs ibpb stibp tpr_shadow vnmi ept vpid ept_ad fsgsbase tsc_adjust bmi1 avx2 smep
                                 bmi2 invpcid rdseed adx smap xsaveopt arat md_clear flush_l1d arch_capabilities
```

The install prerequisites looks for the US spelling of Virtualization and fails.  Simple update to support both variations.  Tested locally and working as expected with this.  HTH :-) 