### PR TITLE
Add autoinstall runc, containerd for ARM64

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,11 @@ To be able to run kubefire commands w/o issues like node/cluster management, the
 Please run `kubefire install` command with root permission (or sudo without password) to install or update these prerequisites via the below steps.
 
 - Check virtualization supported
-- Install necessary components including runc, containerd, CNI plugins, and Ignite
+- Install necessary components including runc, containerd, CNI plugins, and Ignite. See below minimum required versions of components
+  - RuncVersion >= v1.1.3
+  - ContainerdVersion >= v1.6.6
+  - CniVersion >= v1.1.1
+  - IgniteVersion >= v0.10.0
 
 > Notes: 
 > - To uninstall the prerequisites, run `kubefire uninstall`.

--- a/README.md
+++ b/README.md
@@ -55,8 +55,6 @@ Please run `kubefire install` command with root permission (or sudo without pass
 > Notes: 
 > - To uninstall the prerequisites, run `kubefire uninstall`.
 > - To check the installation status, run `kubefire info`. 
-> - For ARM64, `containerd` and `runc` will not be automatically installed by `kubefire install`, because there are no official ARM64 artifacts provided by https://github.com/containerd/containerd and https://github.com/opencontainers/runc. 
-> Please install manually via package manager on host (ex: Ubuntu apt, OpenSUSE zypper, CentOS yum, etc).
 
 [![asciicast](https://asciinema.org/a/tQKqYjojnsgZOjZqrGbF9Zqh0.svg)](https://asciinema.org/a/tQKqYjojnsgZOjZqrGbF9Zqh0)
 

--- a/scripts/install-prerequisites.sh
+++ b/scripts/install-prerequisites.sh
@@ -52,7 +52,7 @@ function _check_version() {
 }
 
 function check_virtualization() {
-  if [ ${ARCH} = aarch64 ]; then
+  if [ ${ARCH_SUFFIX} = arm64 ]; then
     return
   fi
 

--- a/scripts/install-prerequisites.sh
+++ b/scripts/install-prerequisites.sh
@@ -23,9 +23,9 @@ fi
 STABLE_KUBEFIRE_VERSION=$(sed -E "s/(v[0-9]+\.[0-9]+\.[0-9]+)[a-zA-Z0-9\-]*/\1/g"< <(echo "$KUBEFIRE_VERSION"))
 
 if [ ${ARCH} = aarch64 ] || [ ${ARCH} = arm64 ]; then
-  ARCH_SUFFIX = arm64
-elif [ ${ARCH} = x86_64 ]
-  ARCH_SUFFIX = amd64
+  ARCH_SUFFIX=arm64
+elif [ ${ARCH} = x86_64 ]; then
+  ARCH_SUFFIX=amd64
 fi
 
 rm -rf $TMP_DIR && mkdir -p $TMP_DIR

--- a/scripts/install-prerequisites.sh
+++ b/scripts/install-prerequisites.sh
@@ -66,11 +66,6 @@ function install_containerd() {
   local dir=containerd-$version
 
 
-  if _is_arm_arch; then
-    echo "!!! Please install containerd aarch64 via system package manager, because there is no official aarch64 release from the github repo. !!!"
-    return
-  fi
-
   curl -sfSLO "https://github.com/containerd/containerd/releases/download/${CONTAINERD_VERSION}/containerd-${version}-linux-${GOARCH}.tar.gz"
   mkdir -p $dir
   tar -zxvf $dir*.tar.gz -C $dir
@@ -95,12 +90,8 @@ function install_runc() {
     return
   fi
 
-  if _is_arm_arch; then
-    echo "!!! Please install runc aarch64 via system package manager, because there is no official aarch64 release from the github repo. !!!"
-    return
-  fi
 
-  curl -sfSL "https://github.com/opencontainers/runc/releases/download/${RUNC_VERSION}/runc.amd64" -o runc
+  curl -sfSL "https://github.com/opencontainers/runc/releases/download/${RUNC_VERSION}/runc.${GOARCH}" -o runc
   chmod +x runc
   sudo mv runc /usr/local/bin/
 }

--- a/scripts/install-prerequisites.sh
+++ b/scripts/install-prerequisites.sh
@@ -26,6 +26,9 @@ if [ ${ARCH} = aarch64 ] || [ ${ARCH} = arm64 ]; then
   ARCH_SUFFIX=arm64
 elif [ ${ARCH} = x86_64 ]; then
   ARCH_SUFFIX=amd64
+else
+  echo "${ARCH} is not supported!" >/dev/stderr
+  exit 1
 fi
 
 rm -rf $TMP_DIR && mkdir -p $TMP_DIR

--- a/scripts/uninstall-prerequisites.sh
+++ b/scripts/uninstall-prerequisites.sh
@@ -22,20 +22,10 @@ function ask() {
 }
 
 function uninstall_containerd() {
-  if _is_arm_arch; then
-    echo "!!! Please uninstall containerd aarch64 via system package manager !!!"
-    return
-  fi
-
   sudo rm -f /usr/local/bin/containerd* /usr/local/bin/ctr
 }
 
 function uninstall_runc() {
-  if _is_arm_arch; then
-    echo "!!! Please uninstall containerd aarch64 via system package manager !!!"
-    return
-  fi
-
   sudo rm -f /usr/local/bin/runc
 }
 


### PR DESCRIPTION
Hello!

Some latest runc, containerd publish arm64 binaries regulary.
Suppoused components version by [Makefile](https://github.com/serjs/kubefire/blob/master/Makefile#L20-L23) included supported binaries.

We can changed those versions as min required (becuase it's in mainline and tested already) in Readme.

In future, for those who can use older version (if they create issue or it's popular request), we can change validation logic based on versions too, but currently I decide to not include this in install preq script, skipping constraint complication logic.